### PR TITLE
fix build environment target

### DIFF
--- a/tasks/envpreprocess.js
+++ b/tasks/envpreprocess.js
@@ -28,7 +28,7 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('envpreprocess', 'preprocess environment variables', function() {      
       
     //default environment to 'dev', and grab destination
-    var environment = "dev",
+    var environment = this.target || "dev",
         dest = this.data.options.replacePath;
         //dest = this.data.files.dest;
       


### PR DESCRIPTION
Hello, I noticed the task always used the "dev" target environment, because of the `environment` variable initialization (set to `dev`). This PR fixes it so it use the environment given as `target`
